### PR TITLE
Add frontmatter titles to site sidebar

### DIFF
--- a/site/helpers/pages.groovy
+++ b/site/helpers/pages.groovy
@@ -25,11 +25,37 @@ return { Object context, Options options ->
                 def relativePath = root.toPath().relativize(file.toPath()).toString().replace(File.separator, "/")
                 def name = file.name.replaceFirst(/(?i)\.(md|html?)$/, "")
 
-                items << [
+                // Look for a YAML front matter block and extract the title when present
+                def title
+                if (file.name.toLowerCase().endsWith(".md")) {
+                    def lines = file.readLines()
+                    if (lines && lines[0] ==~ /^---\s*$/) {
+                        def yamlLines = []
+                        for (int i = 1; i < lines.size(); i++) {
+                            def line = lines[i]
+                            if (line ==~ /^---\s*$/) {
+                                break
+                            }
+                            yamlLines << line
+                        }
+                        yamlLines.each { l ->
+                            def m = l =~ /^\s*title\s*:\s*(.+)\s*$/
+                            if (m) {
+                                title = m[0][1].trim().replaceAll(/^['"]|['"]\$/, '')
+                            }
+                        }
+                    }
+                }
+
+                def item = [
                         type: 'file',
                         name: name,
                         path: relativePath
                 ]
+                if (title) {
+                    item.title = title
+                }
+                items << item
             }
         }
 

--- a/site/partials/sidebarItem.hbs
+++ b/site/partials/sidebarItem.hbs
@@ -9,5 +9,5 @@
         </ul>
     </li>
 {{else if (eq type "file")}}
-    <li class="file"><a href="{{#if @root.baseUrl}}{{@root.baseUrl}}/{{htmlPath path}}{{else}}/{{htmlPath path}}{{/if}}">{{name}}</a></li>
+    <li class="file"><a href="{{#if @root.baseUrl}}{{@root.baseUrl}}/{{htmlPath path}}{{else}}/{{htmlPath path}}{{/if}}">{{#if title}}{{title}}{{else}}{{name}}{{/if}}</a></li>
 {{/if}}


### PR DESCRIPTION
## Summary
- parse YAML front matter in `pages` helper to capture `title`
- render `title` in sidebar items when present, falling back to file name

## Testing
- `./gradlew build` *(fails: Included build '/workspace/grimoire' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b0f51724833088dcd9378f42092e