### PR TITLE
Add frontmatter titles to site sidebar

### DIFF
--- a/site/helpers/pages.groovy
+++ b/site/helpers/pages.groovy
@@ -1,5 +1,6 @@
 import com.github.jknack.handlebars.Helper
 import com.github.jknack.handlebars.Options
+import groovy.util.ConfigSlurper
 
 return { Object context, Options options ->
     def pagesDir = options.context.get('pagesDir') as File
@@ -25,11 +26,39 @@ return { Object context, Options options ->
                 def relativePath = root.toPath().relativize(file.toPath()).toString().replace(File.separator, "/")
                 def name = file.name.replaceFirst(/(?i)\.(md|html?)$/, "")
 
-                items << [
+                // Look for a Groovy front matter block and extract the title when present
+                def title
+                if (file.name.toLowerCase().endsWith(".md")) {
+                    def lines = file.readLines()
+                    if (lines && lines[0] ==~ /^---\s*$/) {
+                        def fmLines = []
+                        for (int i = 1; i < lines.size(); i++) {
+                            def line = lines[i]
+                            if (line ==~ /^---\s*$/) {
+                                break
+                            }
+                            fmLines << line
+                        }
+                        if (fmLines) {
+                            try {
+                                def config = new ConfigSlurper().parse(fmLines.join("\n"))
+                                title = config.title?.toString()
+                            } catch (ignored) {
+                                // ignore malformed front matter
+                            }
+                        }
+                    }
+                }
+
+                def item = [
                         type: 'file',
                         name: name,
                         path: relativePath
                 ]
+                if (title) {
+                    item.title = title
+                }
+                items << item
             }
         }
 

--- a/site/partials/sidebarItem.hbs
+++ b/site/partials/sidebarItem.hbs
@@ -9,5 +9,5 @@
         </ul>
     </li>
 {{else if (eq type "file")}}
-    <li class="file"><a href="{{#if @root.baseUrl}}{{@root.baseUrl}}/{{htmlPath path}}{{else}}/{{htmlPath path}}{{/if}}">{{name}}</a></li>
+    <li class="file"><a href="{{#if @root.baseUrl}}{{@root.baseUrl}}/{{htmlPath path}}{{else}}/{{htmlPath path}}{{/if}}">{{#if title}}{{title}}{{else}}{{name}}{{/if}}</a></li>
 {{/if}}


### PR DESCRIPTION
## Summary
- parse Groovy front matter in `pages` helper to capture `title`
- render `title` in sidebar items when present, falling back to file name

## Testing
- `./gradlew build` *(fails: Included build '/workspace/grimoire' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b0f51724833088dcd9378f42092e